### PR TITLE
Fix: Sign In API

### DIFF
--- a/api/1.0/controller/users/signin.controller.js
+++ b/api/1.0/controller/users/signin.controller.js
@@ -27,9 +27,8 @@ export default async function signinHandler(req, res, next) {
   }
   if (!result) return res.status(400).json({ error: "User Not found!" });
 
-  compareSync(password, result.password, (err, result) => {
-    if (err) return res.status(403).json({ error: "Wrong Password" });
-  });
+  if (!compareSync(password, result.password))
+    return res.status(403).json({ error: "Wrong Password" });
   delete result.password;
 
   res.status(200).json({


### PR DESCRIPTION
# Description

1. Wrong password should throw an error, now it can throw it successfully.