### PR TITLE
Fix: add is_public constraint and column in SQL queries

### DIFF
--- a/api/1.0/model/events/detail.model.js
+++ b/api/1.0/model/events/detail.model.js
@@ -19,7 +19,7 @@ SELECT
 BIN_TO_UUID(E.id) AS event_id,
 BIN_TO_UUID(E.host_id) AS host_id,
 E.name, E.shop_name, E.latitude, E.longitude,
-E.people_limit, E.people_joined, E.appointment_time,
+E.people_limit, E.people_joined, E.appointment_time, E.is_public,
 Floor(ST_Distance_Sphere(POINT(?, ?), POINT(E.longitude, E.latitude))) AS distance,
 CASE WHEN J.participant_id IS NOT NULL THEN 1 ELSE 0 END AS is_joined
 FROM events E

--- a/api/1.0/model/events/range.model.js
+++ b/api/1.0/model/events/range.model.js
@@ -1,13 +1,13 @@
 import db from "../db.js";
 
 const rangeQuery = `
-SELECT BIN_TO_UUID(id) AS event_id, BIN_TO_UUID(host_id) AS host_id, 
+SELECT BIN_TO_UUID(id) AS event_id, BIN_TO_UUID(host_id) AS host_id, is_public
 ( SELECT picture FROM users WHERE users.id = events.host_id ) AS picture,
 name, shop_name, latitude, longitude, people_limit, people_joined, appointment_time,
 Floor(ST_Distance_Sphere(POINT(?, ?), POINT(longitude, latitude))) AS distance,
 ( SELECT COUNT(*) FROM participants WHERE participants.user_id = UUID_TO_BIN(?) AND participants.event_id = events.id ) AS is_joined 
 FROM events
-WHERE status=FALSE
+WHERE status=FALSE AND is_public=TRUE
 ORDER BY is_joined DESC, distance;
 `;
 

--- a/api/1.0/model/events/search.model.js
+++ b/api/1.0/model/events/search.model.js
@@ -3,7 +3,7 @@ import db from "../db.js";
 const searchQuery = `
 SELECT BIN_TO_UUID(id) AS event_id, BIN_TO_UUID(host_id) AS host_id, 
 ( SELECT picture FROM users WHERE users.id = events.host_id ) AS picture,
-name, shop_name, latitude, longitude, people_limit, people_joined, appointment_time,
+name, shop_name, latitude, longitude, people_limit, people_joined, appointment_time, is_public
 Floor(ST_Distance_Sphere(POINT(?, ?), POINT(longitude, latitude))) AS distance,
 ( SELECT COUNT(*) FROM participants WHERE participants.user_id = UUID_TO_BIN(?) AND participants.event_id = events.id ) AS is_joined
 FROM events


### PR DESCRIPTION
# Description

1. In some models, `is_public` column is missing, I added some of them.
2. In a model, `is_public` constraint is missing, I added it back.