### PR TITLE
Fix: Properly release connection

### DIFF
--- a/api/1.0/model/events/create.model.js
+++ b/api/1.0/model/events/create.model.js
@@ -68,8 +68,8 @@ export default async function eventCreate({
 		await con.commit();
 	} catch (err) {
 		await con.rollback();
-		db.releaseConnection();
+		con.release();
 		throw err;
 	}
-	db.releaseConnection();
+	con.release();
 }

--- a/api/1.0/model/events/delete.model.js
+++ b/api/1.0/model/events/delete.model.js
@@ -23,14 +23,14 @@ export default async function eventDelete(eventId, userId) {
 		const [result] = await conn.query(eventsQuery, eventsParams);
 		if (!result.affectedRows) {
 			await conn.rollback();
-			db.releaseConnection();
+			conn.release();
 			return false;
 		}
 		await conn.query(participantsQuery, participantsParams);
 		await conn.commit();
 	} catch (err) {
 		await conn.rollback();
-		db.releaseConnection();
+		conn.release();
 		throw err;
 	}
 	return true;

--- a/api/1.0/model/events/detail.model.js
+++ b/api/1.0/model/events/detail.model.js
@@ -49,10 +49,10 @@ export default async function eventDetail(eventId, userId, longitude, latitude) 
     participantsData = participantResult;
     eventData = eventResult;
   } catch (err) {
-    db.releaseConnection();
+		conn.release();
     throw err;
   }
-  db.releaseConnection();
+	conn.release();
 	eventData[0].participants = participantsData;
   return eventData;
 }

--- a/mysql/JoinEat.sql
+++ b/mysql/JoinEat.sql
@@ -41,7 +41,7 @@ FOREIGN KEY(`event_id`) REFERENCES `events`(`id`) ON DELETE CASCADE
 
 -- checking people limit may be exceed or not
 DELIMITER //
-CREATE TRIGGER check_people_limit
+CREATE TRIGGER IF NOT EXISTS check_people_limit
 BEFORE UPDATE ON events FOR EACH ROW
 BEGIN
 	IF NEW.people_joined > NEW.people_limit THEN
@@ -51,7 +51,7 @@ BEGIN
 END;
 //
 
-CREATE TRIGGER check_host_quit
+CREATE TRIGGER IF NOT EXISTS check_host_quit
 BEFORE DELETE ON participants FOR EACH ROW
 BEGIN
 	DECLARE event_host_id BINARY(16);
@@ -65,19 +65,19 @@ END
 //
 
 -- update people joined
-CREATE PROCEDURE UpdatePeopleJoined(event_id BINARY(16), increment INT)
+CREATE PROCEDURE IF NOT EXISTS UpdatePeopleJoined(event_id BINARY(16), increment INT)
 BEGIN
 	UPDATE events SET people_joined = people_joined + increment
 	WHERE id = event_id;
 END;
 //
-CREATE TRIGGER add_people_joined
+CREATE TRIGGER IF NOT EXISTS add_people_joined
 AFTER INSERT ON participants FOR EACH ROW
 BEGIN
 	CALL UpdatePeopleJoined(NEW.event_id, 1);
 END;
 //
-CREATE TRIGGER dec_people_joined
+CREATE TRIGGER IF NOT EXISTS dec_people_joined
 AFTER DELETE ON participants FOR EACH ROW
 BEGIN
 	CALL UpdatePeopleJoined(OLD.event_id, -1);
@@ -85,7 +85,7 @@ END;
 //
 
 -- check_expired_events
-CREATE EVENT check_expired_events
+CREATE EVENT IF NOT EXISTS check_expired_events
 ON SCHEDULE EVERY 1 MINUTE
 DO
   BEGIN


### PR DESCRIPTION
# Description

1. The release method used in previous versions is wrong, and it is fixed now.
2. Add `IF NOT EXISTS` into `.sql` file, to handle the TABLE/PROCEDURE/TRIGGER/EVENT existed condition.